### PR TITLE
3: Add message footer

### DIFF
--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -3,6 +3,7 @@
 # Notifies users about available appointments in the zips they follow.
 class Notifier < ApplicationService
   DM_HEADER = ['Appointments now available at:', nil].freeze
+  DM_FOOTER = "We'll send you available appointments as soon as we're aware. DM 'stop' to cease notifications."
 
   def initialize(user_zips = UserZip.find_each)
     super()
@@ -17,7 +18,7 @@ class Notifier < ApplicationService
 
       dm_results(results)
     end
-    { clinics: results[:clinics], users: results[:users] }
+    { message: results[:message], clinics: results[:clinics], users: results[:users] }
   end
 
   private
@@ -28,6 +29,7 @@ class Notifier < ApplicationService
     Rails.logger.info "Found #{results[:clinics]} clinics for #{results[:user_zip].zip}."
   end
 
+  # rubocop:disable Metrics/AbcSize
   def message_for_matching_locations(results)
     Location.where('addr2 LIKE ?', "%#{results[:user_zip].zip}%").find_each do |clinic|
       results[:message] ||= DM_HEADER.dup
@@ -36,6 +38,7 @@ class Notifier < ApplicationService
       results[:message] << nil
       results[:clinics] += 1
     end
-    results[:message]
+    results[:message] << DM_FOOTER if results[:message]
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -31,7 +31,7 @@ describe Notifier do
     context 'when a user subscribes to a non-existing Location' do
       let(:user_zips) { [UserZip.new(user_id: 1, zip: '90044')] }
 
-      it { should eq({ clinics: 0, users: 0 }) }
+      it { should include({ clinics: 0, users: 0 }) }
 
       describe 'TWITTER_CLIENT' do
         subject { TWITTER_CLIENT }

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -16,7 +16,9 @@ describe Notifier do
     context 'when a user subscribes to a matching Location' do
       let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210')] }
 
-      it { should eq({ clinics: 1, users: 1 }) }
+      it { should include({ clinics: 1, users: 1 }) }
+
+      specify('message text') { expect(subject[:message]).to include Notifier::DM_FOOTER }
 
       describe 'TWITTER_CLIENT' do
         subject { TWITTER_CLIENT }


### PR DESCRIPTION
This adds the requested footer text to each DM response with appointments:
> We'll send you available appointments as soon as we're aware. DM 'stop' to cease notifications.

Closes #3.