### PR TITLE
4: Accept embedded zips

### DIFF
--- a/app/services/direct_message_reader.rb
+++ b/app/services/direct_message_reader.rb
@@ -20,8 +20,8 @@ class DirectMessageReader < ApplicationService
   private
 
   def dm_is_a_zip_and_user_zip_saved?(direct_message)
-    !(direct_message.text =~ /^[0-9]{5}$/).nil? && UserZip.create_or_find_by(user_id: direct_message.sender_id,
-                                                                             zip: direct_message.text).persisted?
+    !(direct_message.text =~ /[ ,.]*[0-9]{5}[ ,.]*/).nil? &&
+      UserZip.create_or_find_by(user_id: direct_message.sender_id, zip: direct_message.text).persisted?
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/services/direct_message_reader.rb
+++ b/app/services/direct_message_reader.rb
@@ -26,7 +26,6 @@ class DirectMessageReader < ApplicationService
       UserZip.create(user_id: direct_message.sender_id, zip: zip) && results[:subscribed] += 1
       Rails.logger.info "#{direct_message.sender_id} subscribed to #{direct_message.text}."
     end
-    results[:subscribed]
   end
 
   def read(direct_message:, results:)

--- a/spec/services/direct_message_reader_spec.rb
+++ b/spec/services/direct_message_reader_spec.rb
@@ -21,7 +21,7 @@ describe DirectMessageReader do
         it { should eq({ stopped: 0, subscribed: 1 }) }
       end
 
-      context "when DM embeds two zip in other text" do
+      context 'when DM embeds two zip in other text' do
         let(:subscribe_message) do
           msg = double
           allow(msg).to receive(:id).and_return(1)

--- a/spec/services/direct_message_reader_spec.rb
+++ b/spec/services/direct_message_reader_spec.rb
@@ -48,6 +48,19 @@ describe DirectMessageReader do
         it { should eq({ stopped: 1, subscribed: 1 }) }
       end
     end
+    context 'when a user subscribes to two embedded zips' do
+      let(:messages) { [embedded_subscribe_message] }
+      let(:embedded_subscribe_message) do
+        msg = double
+        allow(msg).to receive(:id).and_return(1)
+        allow(msg).to receive(:sender_id).and_return(167_894_675)
+        allow(msg).to receive(:recipient_id).and_return(490_732_052)
+        allow(msg).to receive(:text).and_return('LA County ranges from neighborhoods like 90210 to 90044.')
+        msg
+      end
+
+      it { should eq({ stopped: 0, subscribed: 2 }) }
+    end
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/services/direct_message_reader_spec.rb
+++ b/spec/services/direct_message_reader_spec.rb
@@ -17,21 +17,21 @@ describe DirectMessageReader do
         msg
       end
 
-      context "when user's DM is a zip alone" do
+      context 'when DM is just a zip' do
         it { should eq({ stopped: 0, subscribed: 1 }) }
       end
 
-      context "when user's DM includes a zip alone" do
+      context "when DM embeds two zip in other text" do
         let(:subscribe_message) do
           msg = double
           allow(msg).to receive(:id).and_return(1)
           allow(msg).to receive(:sender_id).and_return(167_894_675)
           allow(msg).to receive(:recipient_id).and_return(490_732_052)
-          allow(msg).to receive(:text).and_return('Please let me know about appointments in 90210. Thanks!')
+          allow(msg).to receive(:text).and_return('LA County ranges from neighborhoods like 90210 to 90044.')
           msg
         end
 
-        it { should eq({ stopped: 0, subscribed: 1 }) }
+        it { should eq({ stopped: 0, subscribed: 2 }) }
       end
 
       context 'when a user unsubscribes' do
@@ -47,19 +47,6 @@ describe DirectMessageReader do
 
         it { should eq({ stopped: 1, subscribed: 1 }) }
       end
-    end
-    context 'when a user subscribes to two embedded zips' do
-      let(:messages) { [embedded_subscribe_message] }
-      let(:embedded_subscribe_message) do
-        msg = double
-        allow(msg).to receive(:id).and_return(1)
-        allow(msg).to receive(:sender_id).and_return(167_894_675)
-        allow(msg).to receive(:recipient_id).and_return(490_732_052)
-        allow(msg).to receive(:text).and_return('LA County ranges from neighborhoods like 90210 to 90044.')
-        msg
-      end
-
-      it { should eq({ stopped: 0, subscribed: 2 }) }
     end
   end
 end

--- a/spec/services/direct_message_reader_spec.rb
+++ b/spec/services/direct_message_reader_spec.rb
@@ -17,7 +17,22 @@ describe DirectMessageReader do
         msg
       end
 
-      it { should eq({ stopped: 0, subscribed: 1 }) }
+      context "when user's DM is a zip alone" do
+        it { should eq({ stopped: 0, subscribed: 1 }) }
+      end
+
+      context "when user's DM includes a zip alone" do
+        let(:subscribe_message) do
+          msg = double
+          allow(msg).to receive(:id).and_return(1)
+          allow(msg).to receive(:sender_id).and_return(167_894_675)
+          allow(msg).to receive(:recipient_id).and_return(490_732_052)
+          allow(msg).to receive(:text).and_return('Please let me know about appointments in 90210. Thanks!')
+          msg
+        end
+
+        it { should eq({ stopped: 0, subscribed: 1 }) }
+      end
 
       context 'when a user unsubscribes' do
         let(:messages) { [subscribe_message, unsubscribe_message] }


### PR DESCRIPTION
Closes: #4

# Goal
Allow users to DM zip codes with supplementary text around them.

# Approach
1. Extract method `DirectMessageReader#create_zips_from_dm`.
2. Use `scan(/\d{5}(?:[-\s]\d{4})?/)` to capture and save each individual zip.