### PR TITLE
2: Linkless locations

### DIFF
--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -17,10 +17,17 @@ class Notifier < ApplicationService
 
       dm_results(results)
     end
-    { clinics: results[:clinics], users: results[:users] }
+    { clinics: results[:clinics], message: results[:message], users: results[:users] }
   end
 
   private
+
+  def clinic_link(clinic)
+    output = []
+    output << "#{clinic.name} (#{clinic.addr1}, #{clinic.addr2})."
+    output << "Check eligibility and sign-up at #{clinic.link}" if clinic.link
+    output * "\n"
+  end
 
   def dm_results(results)
     TWITTER_CLIENT.create_direct_message(results[:user_zip].user_id, results[:message] * "\n")
@@ -31,8 +38,7 @@ class Notifier < ApplicationService
   def message_for_matching_locations(results)
     Location.where('addr2 LIKE ?', "%#{results[:user_zip].zip}%").find_each do |clinic|
       results[:message] ||= DM_HEADER.dup
-      results[:message] <<
-        "#{clinic.name} (#{clinic.addr1}, #{clinic.addr2}). Check eligibility and sign-up at #{clinic.link}"
+      results[:message] << clinic_link(clinic)
       results[:message] << nil
       results[:clinics] += 1
     end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -24,8 +24,7 @@ class Notifier < ApplicationService
   private
 
   def clinic_link(clinic)
-    output = []
-    output << "#{clinic.name} (#{clinic.addr1}, #{clinic.addr2})."
+    output = ["#{clinic.name} (#{clinic.addr1}, #{clinic.addr2})."]
     output << "Check eligibility and sign-up at #{clinic.link}" if clinic.link
     output * "\n"
   end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     addr1 { '300 North Canon Drive' }
     addr2 { 'Beverly Hills, CA 90210' }
     link { 'https://www.riteaid.com/pharmacy/covid-qualifier' }
+
+    trait :location_without_link do
+      link { nil }
+    end
   end
 end

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -17,12 +17,14 @@ describe Notifier do
     context 'when a user subscribes to a matching Location' do
       let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210')] }
 
-      it { should eq({ clinics: 1, users: 1 }) }
+      it { should include({ clinics: 1, users: 1 }) }
 
       context "when Location doesn't have a link" do
-        let(:location) { FactoryBot.create(:location, :location_without_link) }
+        describe 'message text' do
+          let(:location) { FactoryBot.create(:location, :location_without_link) }
 
-        specify('message text') { expect(subject[:message]).not_to include(/sign-up at/i) }
+          specify { expect(subject[:message].join).not_to match(/sign-up at/i) }
+        end
       end
 
       describe 'TWITTER_CLIENT' do
@@ -36,7 +38,7 @@ describe Notifier do
     context 'when a user subscribes to a non-existing Location' do
       let(:user_zips) { [UserZip.new(user_id: 1, zip: '90044')] }
 
-      it { should eq({ clinics: 0, users: 0 }) }
+      it { should include({ clinics: 0, users: 0 }) }
 
       describe 'TWITTER_CLIENT' do
         subject { TWITTER_CLIENT }

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -8,15 +8,22 @@ describe Notifier do
 
     before do
       allow(TWITTER_CLIENT).to receive(:create_direct_message)
-      FactoryBot.create(:location)
+      location
     end
 
+    let(:location) { FactoryBot.create(:location) }
     let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210')] }
 
     context 'when a user subscribes to a matching Location' do
       let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210')] }
 
       it { should eq({ clinics: 1, users: 1 }) }
+
+      context "when Location doesn't have a link" do
+        let(:location) { FactoryBot.create(:location, :location_without_link) }
+
+        specify('message text') { expect(subject[:message]).not_to include(/sign-up at/i) }
+      end
 
       describe 'TWITTER_CLIENT' do
         subject { TWITTER_CLIENT }


### PR DESCRIPTION
Closes: #2

# Goal
Add link text conditionally to DM content, so "Check eligibility and sign-up at" doesn't show up without URLs.

# Approach
1. Extract method `clinic_link(clinic)` to build the link string for each `Location`.
2. Expose resulting `message` text in the results `Notifier.call` returns to facilitate testing.