### PR TITLE
14 repeated footer

### DIFF
--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -15,7 +15,9 @@ class Notifier < ApplicationService
     @user_zips.each do |user_zip|
       results[:user_zip] = user_zip
       next unless message_for_matching_locations(results)
-
+    end
+    if results[:message]
+      results[:message] << DM_FOOTER
       dm_results(results)
     end
     { clinics: results[:clinics], message: results[:message], users: results[:users] }
@@ -35,7 +37,6 @@ class Notifier < ApplicationService
     Rails.logger.info "Found #{results[:clinics]} clinics for #{results[:user_zip].zip}."
   end
 
-  # rubocop:disable Metrics/AbcSize
   def message_for_matching_locations(results)
     Location.where('addr2 LIKE ?', "%#{results[:user_zip].zip}%").find_each do |clinic|
       results[:message] ||= DM_HEADER.dup
@@ -43,7 +44,6 @@ class Notifier < ApplicationService
       results[:message] << nil
       results[:clinics] += 1
     end
-    results[:message] << DM_FOOTER if results[:message]
+    results[:message]
   end
-  # rubocop:enable Metrics/AbcSize
 end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :location do
-    organization { 'Reported' }
     name { 'Rite Aid Pharmacy #5462' }
     addr1 { '300 North Canon Drive' }
     addr2 { 'Beverly Hills, CA 90210' }
@@ -10,6 +9,12 @@ FactoryBot.define do
 
     trait :location_without_link do
       link { nil }
+    end
+    trait 90044 do
+      name { 'Crenshaw Clinic' }
+      addr1 { '1261 W 79th Street' }
+      addr2 { 'Los Angeles, CA 90044' }
+      link { 'https://carbonhealth.com/covid-19-vaccines' }
     end
   end
 end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     trait :location_without_link do
       link { nil }
     end
-    trait 90044 do
+    trait '90044' do
       name { 'Crenshaw Clinic' }
       addr1 { '1261 W 79th Street' }
       addr2 { 'Los Angeles, CA 90044' }

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -12,20 +12,21 @@ describe Notifier do
     end
 
     let(:location) { FactoryBot.create(:location) }
-    let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210')] }
 
     context 'when a user subscribes to a matching Location' do
       let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210')] }
 
       it { should include({ clinics: 1, users: 1 }) }
 
-      specify('message text') { expect(subject[:message]).to include Notifier::DM_FOOTER }
+      describe 'message text' do
+        it { expect(subject[:message]).to include Notifier::DM_FOOTER }
+      end
 
       context "when Location doesn't have a link" do
         describe 'message text' do
           let(:location) { FactoryBot.create(:location, :location_without_link) }
 
-          specify { expect(subject[:message].join).not_to match(/sign-up at/i) }
+          it { expect(subject[:message].join).not_to match(/sign-up at/i) }
         end
       end
 
@@ -35,6 +36,16 @@ describe Notifier do
         after { Notifier.call(user_zips) }
 
         it { is_expected.to receive(:create_direct_message) }
+      end
+
+      context "when a user subscribes to a second matching Location in another zip code" do
+        before { FactoryBot.create(:location, 90044) }
+
+        let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210'), UserZip.new(user_id: 2, zip: '90044')] }
+
+        describe 'message text' do
+          it { expect(subject[:message].join.scan(Regexp.new("#{Notifier::DM_FOOTER[0..19]}")).count).to eq 1 }
+        end
       end
     end
     context 'when a user subscribes to a non-existing Location' do

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -38,13 +38,13 @@ describe Notifier do
         it { is_expected.to receive(:create_direct_message) }
       end
 
-      context "when a user subscribes to a second matching Location in another zip code" do
-        before { FactoryBot.create(:location, 90044) }
+      context 'when a user subscribes to a second matching Location in another zip code' do
+        before { FactoryBot.create(:location, '90044') }
 
-        let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210'), UserZip.new(user_id: 2, zip: '90044')] }
+        let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210'), UserZip.new(user_id: 1, zip: '90044')] }
 
         describe 'message text' do
-          it { expect(subject[:message].join.scan(Regexp.new("#{Notifier::DM_FOOTER[0..19]}")).count).to eq 1 }
+          it { expect(subject[:message].join.scan(Regexp.new((Notifier::DM_FOOTER[0..19]).to_s)).count).to eq 1 }
         end
       end
     end


### PR DESCRIPTION
Closes: #14

# Goal
Make sure the DM's footer appears only once.

# Approach
1. Concatenate `DM_FOOTER` outside *both* the `UserZip` and  `Location` loops.