### PR TITLE
doc: added Inch-CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![test](https://github.com/ivanoblomov/vaccine-notifier/actions/workflows/test.yml/badge.svg)](https://github.com/ivanoblomov/vaccine-notifier/actions/workflows/test.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/dad2d32da2d576e4a99a/maintainability)](https://codeclimate.com/github/ivanoblomov/vaccine-notifier/maintainability)
 [![Coverage Status](https://coveralls.io/repos/github/ivanoblomov/vaccine-notifier/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/ivanoblomov/vaccine-notifier?branch=main)
+[![Inline docs](http://inch-ci.org/github/ivanoblomov/vaccine-notifier.svg?branch=main)](http://inch-ci.org/github/ivanoblomov/vaccine-notifier)
 
 This bot notifies LA County users who tweet their zip codes to [@vaccinesignup](https://twitter.com/vaccinesignup/) about available vaccine appointments in their area.
 


### PR DESCRIPTION
Closes: #17 

# Goal
Encourage documentation by adding Inch CI to the project.

# Approach
1. Add badge which links to [Inch CI](http://inch-ci.org/github/ivanoblomov/vaccine-notifier).