### PR TITLE
LocationSyncer spec

### DIFF
--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
     addr2 { 'Beverly Hills, CA 90210' }
     link { 'https://www.riteaid.com/pharmacy/covid-qualifier' }
 
+    trait :with_bad_name do
+      name { 'Rite Aid Pharmacy' }
+    end
     trait :location_without_link do
       link { nil }
     end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     trait :with_bad_name do
       name { 'Rite Aid Pharmacy' }
     end
-    trait :location_without_link do
+    trait :without_link do
       link { nil }
     end
     trait '90044' do

--- a/spec/services/location_syncer_spec.rb
+++ b/spec/services/location_syncer_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 require "#{File.dirname(__FILE__)}/../spec_helper"
-describe LocationSyncer do
-  LOCATION_ATTRIBUTES = {
-    :name => "Rite Aid Pharmacy #5462",
-    :addr1 => "300 North Canon Drive",
-    :addr2 => "Beverly Hills, CA 90210",
-    :link => "https://www.riteaid.com/pharmacy/covid-qualifier"
-  }
+LOCATION_ATTRIBUTES = {
+  name: 'Rite Aid Pharmacy #5462',
+  addr1: '300 North Canon Drive',
+  addr2: 'Beverly Hills, CA 90210',
+  link: 'https://www.riteaid.com/pharmacy/covid-qualifier'
+}.freeze
 
+# rubocop:disable Metrics/BlockLength
+describe LocationSyncer do
   let(:location) { Location.first }
   let(:locations) { JSON.parse(File.read('./spec/fixtures/locations.json')) }
 
@@ -49,3 +50,4 @@ describe LocationSyncer do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/services/location_syncer_spec.rb
+++ b/spec/services/location_syncer_spec.rb
@@ -2,6 +2,14 @@
 
 require "#{File.dirname(__FILE__)}/../spec_helper"
 describe LocationSyncer do
+  LOCATION_ATTRIBUTES = {
+    :name => "Rite Aid Pharmacy #5462",
+    :addr1 => "300 North Canon Drive",
+    :addr2 => "Beverly Hills, CA 90210",
+    :link => "https://www.riteaid.com/pharmacy/covid-qualifier"
+  }
+
+  let(:location) { Location.first }
   let(:locations) { JSON.parse(File.read('./spec/fixtures/locations.json')) }
 
   describe '#call' do
@@ -9,12 +17,35 @@ describe LocationSyncer do
 
     context 'when no Locations exist' do
       it { should eq({ total: 1, new: 1, updated: 0 }) }
-    end
 
+      context 'creates Location' do
+        before { LocationSyncer.call(locations) }
+
+        LOCATION_ATTRIBUTES.each do |key, value|
+          describe "Location##{key}" do
+            subject { location.send(key) }
+
+            it { should eq value }
+          end
+        end
+      end
+    end
     context 'when a matching Location exists' do
-      before { FactoryBot.create(:location) }
+      before { FactoryBot.create(:location, :with_bad_name) }
 
       it { should eq({ total: 1, new: 0, updated: 1 }) }
+
+      context 'updates Location' do
+        before { LocationSyncer.call(locations) }
+
+        LOCATION_ATTRIBUTES.each do |key, value|
+          describe "Location##{key}" do
+            subject { location.send(key) }
+
+            it { should eq value }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -24,7 +24,7 @@ describe Notifier do
 
       context "when Location doesn't have a link" do
         describe 'message text' do
-          let(:location) { FactoryBot.create(:location, :location_without_link) }
+          let(:location) { FactoryBot.create(:location, :without_link) }
 
           it { expect(subject[:message].join).not_to match(/sign-up at/i) }
         end


### PR DESCRIPTION
Closes: #16

# Goal
Test `Location` creation/updates explicitly, rather than just checking tallies.

# Approach
1. Iterate across `LOCATION_ATTRIBUTES` and assert the *created* `Location` has the expected values.
2. Create a `Location` with a faulty name using the `:with_bad_name` factory and assert the *updated* `Location` has the expected values.