### PR TITLE
Add Location#la_id

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -18,7 +18,7 @@ class Location < ApplicationRecord
   # @return [Location] the matching Location
   # @example
   #   Location.find_by_best_key('1', '1261 W 79th Street')
-  def self.find_by_best_key(id, address1)
-    Location.where('id = ? OR addr1 = ?', id.to_i, address1).limit(1).find_each.first
+  def self.find_by_best_key(la_id:, address1:)
+    Location.where('la_id = ? OR addr1 = ?', la_id.to_i, address1).limit(1).find_each.first
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -28,6 +28,12 @@ class Location < ApplicationRecord
     end.first
   end
 
+  # Finds or initializes the Location with the specified attributes.
+  #
+  # @param attr [Hash] the attributes for the Location
+  # @return [Location] the found or initialized Location
+  # @example
+  #   Location.find_or_init({ la_id: '1', address1: '1261 W 79th Street' })
   def self.find_or_init(attr)
     la_id = attr.delete('id')
     location = find_by_best_key(la_id: la_id, address1: attr['addr1']) || Location.new(la_id: la_id)
@@ -35,6 +41,9 @@ class Location < ApplicationRecord
     location
   end
 
+  # Returns the Location's zip code.
+  #
+  # @return [String] the zip code
   def zip
     @zip ||= addr2.scan(/\d{5}(?:[-\s]\d{4})?/).first
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -13,12 +13,29 @@ class Location < ApplicationRecord
 
   # Finds the Location matching the specified ID or street address.
   #
-  # @param id [String] the Location's ID
+  # @param la_id [String] the Location's ID from LA County
   # @param address1 [String] the Location's street address line 1
   # @return [Location] the matching Location
   # @example
-  #   Location.find_by_best_key('1', '1261 W 79th Street')
+  #   Location.find_by_best_key(la_id: '1', address1: '1261 W 79th Street')
   def self.find_by_best_key(la_id:, address1:)
-    Location.where('la_id = ? OR addr1 = ?', la_id.to_i, address1).limit(1).find_each.first
+    if la_id.present?
+      Location.where('la_id = ?', la_id.to_s)
+    elsif address1.present?
+      Location.where('addr1 = ?', address1.to_s)
+    else
+      Location.none
+    end.first
+  end
+
+  def self.find_or_init(attr)
+    la_id = attr.delete('id')
+    location = find_by_best_key(la_id: la_id, address1: attr['addr1']) || Location.new(la_id: la_id)
+    location.attributes = attr
+    location
+  end
+
+  def zip
+    @zip ||= addr2.scan(/\d{5}(?:[-\s]\d{4})?/).first
   end
 end

--- a/app/services/location_syncer.rb
+++ b/app/services/location_syncer.rb
@@ -32,7 +32,7 @@ class LocationSyncer < ApplicationService
   def call
     results = { new: 0, updated: 0 }
     results[:total] = @locations.each do |attr|
-      location = Location.find_by_best_key(attr.delete('id'), attr['addr1']) || Location.new
+      location = Location.find_by_best_key(la_id: attr.delete('id'), address1: attr['addr1']) || Location.new
       location.attributes = attr
       (location.new_record? && results[:new] += 1) || (location.changed? && results[:updated] += 1)
       location.save

--- a/app/services/location_syncer.rb
+++ b/app/services/location_syncer.rb
@@ -21,26 +21,34 @@ class LocationSyncer < ApplicationService
   # Creates or updates Locations based on the array of location-attribute
   # hashes @locations.
   #
-  # @return [Hash] results tallying new, updated, and total Locations
+  # @return [Hash] results tallying zips and new, updated, and total Locations
   # @example
   #   LocationSyncer.call
   #     => {
-  #             :new => 3,
-  #         :updated => 37,
-  #           :total => 403
+  #             :new => 388,
+  #         :updated => 0,
+  #            :zips => [
+  #                       "90044",
+  #                       "91340",
+  #                       ...
+  #                     ],
+  #           :total => 405
   #     }
+  # rubocop:disable Metrics/AbcSize
   def call
-    results = { new: 0, updated: 0 }
+    results = { new: 0, updated: 0, zips: Set.new }
     results[:total] = @locations.each do |attr|
-      la_id = attr.delete('id')
-      location = Location.find_by_best_key(la_id: la_id, address1: attr['addr1']) || Location.new(la_id: la_id)
-      location.attributes = attr
-      (location.new_record? && results[:new] += 1) || (location.changed? && results[:updated] += 1)
+      next if attr['addr1'].blank?
+
+      location = Location.find_or_init(attr)
+      results[:zips] << location.zip if (location.new_record? && results[:new] += 1) ||
+                                        (location.changed? && results[:updated] += 1)
       location.save
     end.size
     log_results(results)
     results
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/services/location_syncer.rb
+++ b/app/services/location_syncer.rb
@@ -32,7 +32,8 @@ class LocationSyncer < ApplicationService
   def call
     results = { new: 0, updated: 0 }
     results[:total] = @locations.each do |attr|
-      location = Location.find_by_best_key(la_id: attr.delete('id'), address1: attr['addr1']) || Location.new
+      la_id = attr.delete('id')
+      location = Location.find_by_best_key(la_id: la_id, address1: attr['addr1']) || Location.new(la_id: la_id)
       location.attributes = attr
       (location.new_record? && results[:new] += 1) || (location.changed? && results[:updated] += 1)
       location.save

--- a/db/migrate/20210323013905_add_la_id_to_locations.rb
+++ b/db/migrate/20210323013905_add_la_id_to_locations.rb
@@ -1,0 +1,6 @@
+class AddLaIdToLocations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :locations, :la_id, :string
+    add_index :locations, :la_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,9 @@
 
 ActiveRecord::Schema.define(version: 2021_03_23_013905) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "locations", force: :cascade do |t|
     t.string "x_parent"
     t.integer "num_children"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,9 +12,6 @@
 
 ActiveRecord::Schema.define(version: 2021_03_23_013905) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
   create_table "locations", force: :cascade do |t|
     t.string "x_parent"
     t.integer "num_children"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_11_170923) do
+ActiveRecord::Schema.define(version: 2021_03_23_013905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,9 @@ ActiveRecord::Schema.define(version: 2021_03_11_170923) do
     t.string "system"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "la_id"
     t.index ["addr1"], name: "index_locations_on_addr1"
+    t.index ["la_id"], name: "index_locations_on_la_id"
   end
 
   create_table "read_direct_messages", force: :cascade do |t|

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
     addr2 { 'Beverly Hills, CA 90210' }
     link { 'https://www.riteaid.com/pharmacy/covid-qualifier' }
 
+    trait :with_bad_name do
+      name { 'Rite Aid Pharmacy' }
+    end
     trait :location_without_link do
       link { nil }
     end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     name { 'Rite Aid Pharmacy #5462' }
     addr1 { '300 North Canon Drive' }
     addr2 { 'Beverly Hills, CA 90210' }
+    la_id { '5462' }
     link { 'https://www.riteaid.com/pharmacy/covid-qualifier' }
 
     trait :with_bad_name do

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     trait :with_bad_name do
       name { 'Rite Aid Pharmacy' }
     end
-    trait :location_without_link do
+    trait :without_link do
       link { nil }
     end
     trait '90044' do

--- a/spec/fixtures/locations.json
+++ b/spec/fixtures/locations.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "",
+    "id": "5462",
     "xParent": 8,
     "NumChildren": 0,
     "inactive": "",

--- a/spec/services/location_syncer_spec.rb
+++ b/spec/services/location_syncer_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 require "#{File.dirname(__FILE__)}/../spec_helper"
-describe LocationSyncer do
-  LOCATION_ATTRIBUTES = {
-    :name => "Rite Aid Pharmacy #5462",
-    :addr1 => "300 North Canon Drive",
-    :addr2 => "Beverly Hills, CA 90210",
-    :link => "https://www.riteaid.com/pharmacy/covid-qualifier"
-  }
+LOCATION_ATTRIBUTES = {
+  name: 'Rite Aid Pharmacy #5462',
+  addr1: '300 North Canon Drive',
+  addr2: 'Beverly Hills, CA 90210',
+  link: 'https://www.riteaid.com/pharmacy/covid-qualifier'
+}.freeze
 
+# rubocop:disable Metrics/BlockLength
+describe LocationSyncer do
   let(:location) { Location.first }
   let(:locations) { JSON.parse(File.read('./spec/fixtures/locations.json')) }
 
@@ -49,3 +50,4 @@ describe LocationSyncer do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/services/location_syncer_spec.rb
+++ b/spec/services/location_syncer_spec.rb
@@ -2,6 +2,14 @@
 
 require "#{File.dirname(__FILE__)}/../spec_helper"
 describe LocationSyncer do
+  LOCATION_ATTRIBUTES = {
+    :name => "Rite Aid Pharmacy #5462",
+    :addr1 => "300 North Canon Drive",
+    :addr2 => "Beverly Hills, CA 90210",
+    :link => "https://www.riteaid.com/pharmacy/covid-qualifier"
+  }
+
+  let(:location) { Location.first }
   let(:locations) { JSON.parse(File.read('./spec/fixtures/locations.json')) }
 
   describe '#call' do
@@ -9,12 +17,35 @@ describe LocationSyncer do
 
     context 'when no Locations exist' do
       it { should eq({ total: 1, new: 1, updated: 0 }) }
-    end
 
+      context 'creates Location' do
+        before { LocationSyncer.call(locations) }
+
+        LOCATION_ATTRIBUTES.each do |key, value|
+          describe "Location##{key}" do
+            subject { location.send(key) }
+
+            it { should eq value }
+          end
+        end
+      end
+    end
     context 'when a matching Location exists' do
-      before { FactoryBot.create(:location) }
+      before { FactoryBot.create(:location, :with_bad_name) }
 
       it { should eq({ total: 1, new: 0, updated: 1 }) }
+
+      context 'updates Location' do
+        before { LocationSyncer.call(locations) }
+
+        LOCATION_ATTRIBUTES.each do |key, value|
+          describe "Location##{key}" do
+            subject { location.send(key) }
+
+            it { should eq value }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/location_syncer_spec.rb
+++ b/spec/services/location_syncer_spec.rb
@@ -18,7 +18,7 @@ describe LocationSyncer do
     subject { LocationSyncer.call(locations) }
 
     context 'when no Locations exist' do
-      it { should eq({ total: 1, new: 1, updated: 0 }) }
+      it { should include({ total: 1, new: 1, updated: 0 }) }
 
       context 'creates Location' do
         before { LocationSyncer.call(locations) }
@@ -35,7 +35,7 @@ describe LocationSyncer do
     context 'when a matching Location exists' do
       before { FactoryBot.create(:location, :with_bad_name) }
 
-      it { should eq({ total: 1, new: 0, updated: 1 }) }
+      it { should include({ total: 1, new: 0, updated: 1 }) }
 
       context 'updates Location' do
         before { LocationSyncer.call(locations) }

--- a/spec/services/location_syncer_spec.rb
+++ b/spec/services/location_syncer_spec.rb
@@ -2,6 +2,7 @@
 
 require "#{File.dirname(__FILE__)}/../spec_helper"
 LOCATION_ATTRIBUTES = {
+  la_id: '5462',
   name: 'Rite Aid Pharmacy #5462',
   addr1: '300 North Canon Drive',
   addr2: 'Beverly Hills, CA 90210',

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -24,7 +24,7 @@ describe Notifier do
 
       context "when Location doesn't have a link" do
         describe 'message text' do
-          let(:location) { FactoryBot.create(:location, :location_without_link) }
+          let(:location) { FactoryBot.create(:location, :without_link) }
 
           it { expect(subject[:message].join).not_to match(/sign-up at/i) }
         end


### PR DESCRIPTION
Closes: #21 

# Goal
Save LA County's `id` as `Location#la_id` so there's no possibility of collisions.

# Approach
1. Add migration for `Location#la_id`.
2. Change `Location.find_by_best_key` to search by `#la_id`.
3. Change `LocationSyncer#call` to include updated zips in `results`.

# Notes
See https://github.com/ivanoblomov/vaccine-notifier/issues/10#issuecomment-804231177.