### PR TITLE
f(x): sync_and_notify calls Notifier with updated zips

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/ivanoblomov/vaccine-notifier/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/ivanoblomov/vaccine-notifier?branch=main)
 [![Inline docs](http://inch-ci.org/github/ivanoblomov/vaccine-notifier.svg?branch=main)](http://inch-ci.org/github/ivanoblomov/vaccine-notifier)
 
-This bot notifies LA County users who tweet their zip codes to [@vaccinesignup](https://twitter.com/vaccinesignup/) about available vaccine appointments in their area.
+This bot notifies LA County users who DM their zip codes to [@vaccinesignup](https://twitter.com/vaccinesignup/) about available vaccine appointments in their area.
 
 ## Usage
 

--- a/app/models/read_direct_message.rb
+++ b/app/models/read_direct_message.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
+# Logs read DMs (to prevent duplicate replies).
 class ReadDirectMessage < ApplicationRecord
 end

--- a/app/models/user_zip.rb
+++ b/app/models/user_zip.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Logs which users are subscribed to which zip codes.
 class UserZip < ApplicationRecord
   validates_uniqueness_of :user_id, :zip
 end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -5,11 +5,28 @@ class Notifier < ApplicationService
   DM_HEADER = ['Appointments now available at:', nil].freeze
   DM_FOOTER = "We'll send you available appointments as soon as we're aware. DM 'stop' to cease notifications."
 
+  # Creates a Notifier, setting @user_zips to the specified array of UserZips.
+  # Defaults to all existing UserZips.
+  #
+  # @param user_zips [Array] UserZips
+  # @return [Notifier]
+  # @example
+  #   Notifier.new
   def initialize(user_zips = UserZip.find_each)
     super()
     @user_zips = user_zips
   end
 
+  # DMs users about Locations in zip codes they follow.
+  #
+  # @return [Hash] the message and number of clinics and users DMd
+  # @example
+  #   Notifier.call
+  #     => {
+  #         :clinics => 10,
+  #         :message => ["Appointments now available at:", ...]
+  #           :users => 18
+  #     }
   def call
     results = { clinics: 0, users: 0 }
     @user_zips.each do |user_zip|

--- a/app/services/notify_bot.rb
+++ b/app/services/notify_bot.rb
@@ -2,7 +2,7 @@
 
 require 'net/http'
 
-# Tweet users about new appointments.
+# DM users about new appointments.
 class NotifyBot < ApplicationService
   def call
     Notifier.call if DirectMessageReader.call[:subscribed].positive?

--- a/app/services/sync_and_notify_bot.rb
+++ b/app/services/sync_and_notify_bot.rb
@@ -3,14 +3,14 @@
 require 'net/http'
 
 # Sync Locations and DM users about new appointment-locations.
-class SyncBot < ApplicationService
+class SyncAndNotifyBot < ApplicationService
   # Syncs Locations by calling LocationSyncer.call. If any Locations were
   # created/updated, DMs the updates by calling Notifier.call. In either case,
   # returns results as a Hash.
   #
   # @return [Hash] LocationSyncer or Notifier results
   # @example
-  #   SyncBot.call
+  #   SyncAndNotifyBot.call
   #     => {
   #             :new => 388,
   #         :updated => 0,

--- a/app/services/sync_bot.rb
+++ b/app/services/sync_bot.rb
@@ -2,24 +2,29 @@
 
 require 'net/http'
 
-# Tweet users about new appointments.
+# Sync Locations and DM users about new appointment-locations.
 class SyncBot < ApplicationService
   # Syncs Locations by calling LocationSyncer.call. If any Locations were
-  # created/updated, tweets the updates by calling NotifyBot.call. In either
-  # case, returns results as a Hash.
+  # created/updated, DMs the updates by calling Notifier.call. In either case,
+  # returns results as a Hash.
   #
-  # @return [Hash] results tallying new, updated, and total Locations
+  # @return [Hash] LocationSyncer or Notifier results
   # @example
   #   SyncBot.call
   #     => {
-  #             :new => 3,
-  #         :updated => 37,
-  #           :total => 403
+  #             :new => 388,
+  #         :updated => 0,
+  #            :zips => [
+  #                       "90044",
+  #                       "91340",
+  #                       ...
+  #                     ],
+  #           :total => 405
   #     }
   def call
     results = LocationSyncer.call
-    return results unless (results[:new]).positive? || (results[:updated]).positive?
+    return results unless results[:zips]&.size&.positive?
 
-    NotifyBot.call
+    Notifier.call(UserZip.where(zip: results[:zips]))
   end
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -18,7 +18,7 @@ namespace :vaccinesignup do
 
   desc 'Sync Locations and, if there are changes, notify users.'
   task sync_and_notify: :environment do
-    results = SyncBot.call
+    results = SyncAndNotifyBot.call
     if results
       puts "Notified #{results[:users]} users about #{results[:clinics]} appointments."
       Rails.logger.info "Notified #{results[:users]} users about #{results[:clinics]} appointments."

--- a/spec/services/sync_and_notify_bot_spec.rb
+++ b/spec/services/sync_and_notify_bot_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require "#{File.dirname(__FILE__)}/../spec_helper"
-describe SyncBot do
+describe SyncAndNotifyBot do
   describe '#call' do
     before {  allow(LocationSyncer).to receive(:call).and_return results }
 
-    after { SyncBot.call }
+    after { SyncAndNotifyBot.call }
 
     describe Notifier do
       subject { Notifier }

--- a/spec/services/sync_bot_spec.rb
+++ b/spec/services/sync_bot_spec.rb
@@ -7,16 +7,16 @@ describe SyncBot do
 
     after { SyncBot.call }
 
-    describe NotifyBot do
-      subject { NotifyBot }
+    describe Notifier do
+      subject { Notifier }
 
       context "when there's a new Location" do
-        let(:results) { { new: 1 } }
+        let(:results) { { new: 1, zips: ['00501'] } }
 
         it { should receive(:call) }
       end
       context "when there's an updated Location" do
-        let(:results) { { new: 0, updated: 1 } }
+        let(:results) { { new: 0, updated: 1, zips: ['00501'] } }
 
         it { should receive(:call) }
       end


### PR DESCRIPTION
Closes: #25

# Goal
DM users the updated `Locations` after syncing.

# Approach
1. Call `Notifier.call` with the updated zips codes.
2. Rename classes for clarity.
3. Update documentation for consistency.