### PR TITLE
32 reimport locations

### DIFF
--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -49,8 +49,12 @@ class Notifier < ApplicationService
   end
 
   def dm_results(results)
-    TWITTER_CLIENT.create_direct_message(results[:user_zip].user_id, results[:message] * "\n")
-    results[:users] += 1
+    begin
+      TWITTER_CLIENT.create_direct_message(results[:user_zip].user_id, results[:message] * "\n")
+      results[:users] += 1
+    rescue Twitter::Error => e
+      Rails.logger.error %Q[#{e.class} when DMing user_id #{results[:user_zip].user_id} with...\n#{results[:message] * "\n"}!]
+    end
     Rails.logger.info "Found #{results[:clinics]} clinics for #{results[:user_zip].zip}."
   end
 

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -32,12 +32,12 @@ class Notifier < ApplicationService
     @user_zips.each do |user_zip|
       results[:user_zip] = user_zip
       next unless message_for_matching_locations(results)
-    end
-    if results[:message]
+
       results[:message] << DM_FOOTER
       dm_results(results)
+      results[:message] = nil
     end
-    { clinics: results[:clinics], message: results[:message], users: results[:users] }
+    { clinics: results[:clinics], users: results[:users] }
   end
 
   private

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -11,9 +11,6 @@ FactoryBot.define do
     trait :with_bad_name do
       name { 'Rite Aid Pharmacy' }
     end
-    trait :without_link do
-      link { nil }
-    end
     trait '90044' do
       name { 'Crenshaw Clinic' }
       addr1 { '1261 W 79th Street' }

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -43,6 +43,13 @@ describe Notifier do
 
         let(:user_zips) { [UserZip.new(user_id: 1, zip: '90210'), UserZip.new(user_id: 1, zip: '90044')] }
 
+        describe 'TWITTER_CLIENT' do
+          subject { TWITTER_CLIENT }
+
+          after { Notifier.call(user_zips) }
+
+          it { is_expected.to receive(:create_direct_message).twice }
+        end
         describe 'message text' do
           it { expect(subject[:message].join.scan(Regexp.new((Notifier::DM_FOOTER[0..19]).to_s)).count).to eq 1 }
         end

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -18,18 +18,6 @@ describe Notifier do
 
       it { should include({ clinics: 1, users: 1 }) }
 
-      describe 'message text' do
-        it { expect(subject[:message]).to include Notifier::DM_FOOTER }
-      end
-
-      context "when Location doesn't have a link" do
-        describe 'message text' do
-          let(:location) { FactoryBot.create(:location, :without_link) }
-
-          it { expect(subject[:message].join).not_to match(/sign-up at/i) }
-        end
-      end
-
       describe 'TWITTER_CLIENT' do
         subject { TWITTER_CLIENT }
 
@@ -49,9 +37,6 @@ describe Notifier do
           after { Notifier.call(user_zips) }
 
           it { is_expected.to receive(:create_direct_message).twice }
-        end
-        describe 'message text' do
-          it { expect(subject[:message].join.scan(Regexp.new((Notifier::DM_FOOTER[0..19]).to_s)).count).to eq 1 }
         end
       end
     end


### PR DESCRIPTION
Re: #32

# Goal
Fix two bugs discovered while addressing #32 where:
1. Twitter errors aren't handled.
2. Only one DM is sent(!) per update run.

# Approach
1. Trapped `Twitter::Error`.
2. Covered DM bug.
3. Passed test by:
    1. moving call to `dm_results` *inside* `UserZip` loop
    2. nullifying `results[:message]` to prep for next `UserZip`
4. Deleted tests on `results[:message]` since we no longer have access due to 3ii.