### PR TITLE
Fix output on production

### DIFF
--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -59,8 +59,8 @@ class Notifier < ApplicationService
 #{e.class} when DMing user_id #{results[:user_zip].user_id} with...\n#{results[:message] * "\n"}!
 )
     end
-    Rails.logger.info
-    "DMd user #{results[:user_zip].user_id} #{results[:clinics]} clinics for #{results[:user_zip].zip}."
+    Rails.logger.info "DMd user #{results[:user_zip].user_id} #{results[:clinics]} clinics for "\
+                      "#{results[:user_zip].zip}."
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -10,12 +10,13 @@ namespace :vaccinesignup do
   desc 'Read DMs and, if there are subscribed zip codes, notify users.'
   task read_and_notify: :environment do
     results = NotifyBot.call
-    log_notification_results(results) if results
+    log_notification_results(results) if results && Rails.env.development?
   end
 
   desc 'Sync Locations and, if there are changes, notify users.'
   task sync_and_notify: :environment do
     results = SyncAndNotifyBot.call
+    next unless Rails.env.development?
     if results[:total]
       puts "Parsed #{results[:total]}, created #{results[:new]}, updated #{results[:updated]} Locations, which "\
            "affected these zips: #{results[:zips]}."


### PR DESCRIPTION
# Goal
Fix output on production.

# Approach
1. Fix the blank lines output on production: https://github.com/ivanoblomov/vaccine-notifier/issues/32#issuecomment-808459417.
2. Call `puts` only in development environment.